### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pretty
 
 *Pretty* will detect the configuration file that exist in the current directory and will run the correct tool.
 
-If no configuration file exist, *Pretty* will run PHP-CS-Fixer with PSR-2 by default.
+If no configuration file exist, *Pretty* will run PHP CodeSniffer with PSR-2 by default.
 
 ## Installation
 


### PR DESCRIPTION
*Pretty* will run CodeSniffer and not CS-Fixer by default:
https://github.com/mnapoli/pretty/blob/0652da453d20df1f2848408c04343f9e22a5c096/pretty#L24-L25
https://github.com/mnapoli/pretty/blob/0652da453d20df1f2848408c04343f9e22a5c096/pretty#L12