### PR TITLE
Add `pretty ci` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,19 @@ composer global require mnapoli/pretty
 *Pretty* comes with no dependencies so it should not bring any conflict in Composer.
 
 You can also install it as a local dependency of your project with `composer require mnapoli/pretty`. In that case you can start the tool with `vendor/bin/pretty`.
+
+## Usage
+
+Running pretty is as simple as running:
+
+```
+pretty
+```
+
+In case you are running it in CI, you might want to run:
+
+```
+pretty ci
+```
+
+This will disable the caching option of PHP-CS-Fixer or CodeSniffer (because the cache will not be kept in CI).

--- a/pretty
+++ b/pretty
@@ -4,25 +4,39 @@
 ini_set('display_errors', '1');
 error_reporting(E_ALL);
 
-// TODO: CI option: no cache
 // TODO: "fix" option
 
-const PHP_CS_FIXER_COMMAND = 'php-cs-fixer fix --dry-run --allow-risky=yes --diff';
-const PHP_CODE_SNIFFER_COMMAND = 'phpcs';
-const DEFAULT_COMMAND = 'phpcs --standard=PSR2 --extensions=php --ignore=vendor/* .';
+$commands = [
+    'default' => [
+        'php-cs-fixer' => 'php-cs-fixer fix --dry-run --allow-risky=yes --diff',
+        'phpcs' => 'phpcs',
+        'default' => 'phpcs --standard=PSR2 --extensions=php --ignore=vendor/* .',
+    ],
+    /**
+     * In CI we disable the cache.
+     */
+    'ci' => [
+        'php-cs-fixer' => 'php-cs-fixer fix --dry-run --allow-risky=yes --diff --using-cache=no',
+        'phpcs' => 'phpcs --no-cache',
+        'default' => 'phpcs --standard=PSR2 --extensions=php --ignore=vendor/* --no-cache .',
+    ],
+];
+
+$task = isset($argv[1]) ? $argv[1] : 'default';
+$commands = $commands[$task];
 
 $command = '';
 
 // Detect which tool to run
 if (file_exists('phpcs.xml') || file_exists('phpcs.xml.dist')) {
     echo "CodeSniffer configuration file found, running CodeSniffer\n";
-    $command = PHP_CODE_SNIFFER_COMMAND;
+    $command = $commands['phpcs'];
 } elseif (file_exists('.php_cs') || file_exists('.php_cs.dist')) {
     echo "PHP-CS-Fixer configuration file found, running PHP-CS-Fixer\n";
-    $command = PHP_CS_FIXER_COMMAND;
+    $command = $commands['php-cs-fixer'];
 } else {
     echo "No configuration file found, running PHP CodeSniffer with PSR-2\n";
-    $command = DEFAULT_COMMAND;
+    $command = $commands['default'];
 }
 
 // Run the analysis


### PR DESCRIPTION
This option will disable the caching option of PHP-CS-Fixer or CodeSniffer (because the cache will not be kept in CI).