### PR TITLE
Improve console output

### DIFF
--- a/pretty
+++ b/pretty
@@ -94,6 +94,7 @@ function assertPhpCodeSnifferIsInstalled($command)
         echo <<<INSTRUCTIONS
 ERROR: PHP CodeSniffer does not seem to be installed because the '$command' program cannot be found.
 You can install it by following the instructions here: https://github.com/squizlabs/PHP_CodeSniffer#installation
+
 INSTRUCTIONS;
         exit(1);
     }
@@ -105,6 +106,7 @@ function assertPhpCsFixerIsInstalled()
         echo <<<'INSTRUCTIONS'
 ERROR: PHP-CS-Fixer does not seem to be installed because the 'php-cs-fixer' program cannot be found.
 You can install it by following the instructions here: https://github.com/FriendsOfPHP/PHP-CS-Fixer#installation
+
 INSTRUCTIONS;
         exit(1);
     }
@@ -118,5 +120,6 @@ Available commands:
 - pretty fix: fix as many errors as possible in the code
 - pretty ci: runs an analysis in a continuous integration environment
 - pretty help: displays this help
+
 HELP;
 }


### PR DESCRIPTION
When pretty fails, its output does not end on a new line, displaying something like this:
![capture d ecran de 2018-10-03 14-27-21](https://user-images.githubusercontent.com/22030946/46410418-1548c300-c719-11e8-8cd7-1c9b1b8aebd1.png)

This fix add an empty line to display this:
![capture d ecran de 2018-10-03 14-27-46](https://user-images.githubusercontent.com/22030946/46410425-1974e080-c719-11e8-8005-fc0d9f06407b.png)
