### PR TITLE
Enforce --no-colors in CI mode

### DIFF
--- a/pretty
+++ b/pretty
@@ -52,7 +52,7 @@ $command = '';
 if (file_exists('.phpcs.xml') || file_exists('phpcs.xml') || file_exists('.phpcs.xml.dist') || file_exists('phpcs.xml.dist')) {
     echo "PHP CodeSniffer configuration file found, running CodeSniffer with version\n";
     $command = $commands['phpcs'];
-    $program = explode(' ', $command, 1)[0];
+    $program = explode(' ', $command, 2)[0];
     assertPhpCodeSnifferIsInstalled($program);
 
     passthru($program." --version");

--- a/pretty
+++ b/pretty
@@ -27,8 +27,8 @@ $commands = [
      */
     'ci' => [
         'php-cs-fixer' => 'php-cs-fixer fix --dry-run --allow-risky=yes --diff --using-cache=no',
-        'phpcs' => 'phpcs --no-cache',
-        'default' => 'phpcs --standard=PSR2 --extensions=php --ignore="vendor/*" --no-cache .',
+        'phpcs' => 'phpcs --no-cache --no-colors',
+        'default' => 'phpcs --standard=PSR2 --extensions=php --ignore="vendor/*" --no-cache --no-colors .',
     ],
 ];
 
@@ -88,7 +88,7 @@ function commandExists($command)
     if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
         $return = shell_exec('where ' . escapeshellarg($command));
     } else {
-        $return = shell_exec('which ' . escapeshellarg($command));        
+        $return = shell_exec('which ' . escapeshellarg($command));
     }
     return !empty($return);
 }


### PR DESCRIPTION
I’m not sure if this will solve the problem because:

1. The `pretty` command is called without the `ci` argument in [GitHub checks](https://github.com/morozov/kih/pull/53/checks?check_run_id=430684934).
2. Passing an argument to `pretty` that will internally produce a command with arguments seems not working:
   ```sh
   $ pretty ci
   ERROR: PHP CodeSniffer does not seem to be installed because the 'phpcs --no-cache --no-colors' program cannot be found.
   You can install it by following the instructions here: https://github.com/squizlabs/PHP_CodeSniffer#installation
   ```
   Instead of executing `which phpcs`, `commandExists()` executes `which 'phpcs --no-cache --no-colors'` and fails.